### PR TITLE
fix: add 'export type' to resolve TS1205 error

### DIFF
--- a/mod.ts
+++ b/mod.ts
@@ -1,11 +1,13 @@
 export {
-    FeedType,
+    FeedType
+} from "./src/types/mod.ts";
+export type {
     RSS1,
     RSS2,
     Feed,
     JsonFeed
 } from "./src/types/mod.ts";
 export {
-    deserializeFeed,
-    Options
+    deserializeFeed
 } from "./src/deserializer.ts";
+export type { Options } from "./src/deserializer.ts";


### PR DESCRIPTION
@MikaelPorttila please merge this PR to help resolve a TypeScript compiler error in Deno 1.4.6. The unit tests pass after the minor modfication. Also you may want to resolve the import warning as well.

```
Warning Implicitly using latest version (0.74.0) for https://deno.land/std/testing/asserts.ts
Check file:///home/snshah/workspaces/github.com/shah/rss/$deno$test.ts
running 14 tests
test Mapper ATOM -> JSON Feed ... ok (2ms)
test Mapper RSS2 -> JSON Feed ... ok (2ms)
test Bad input: undefined ... ok (3ms)
test Bad input: null ... ok (1ms)
test Bad input:  ... ok (1ms)
test Unsupported format handling ... ok (4ms)
test Deserialize RSS2 ... ok (7ms)
test Deserialize RSS2 with convertToJsonFeed option ... ok (8ms)
test Deserialize ATOM ... ok (5ms)
test Deserialize ATOM with convertToJsonFeed option ... ok (4ms)
test RSS 1.0 resolver ... ok (1ms)
test RSS 2.0 resolver ... ok (2ms)
test Atom Resolver ... ok (2ms)
test Atom CData field checker ... ok (1ms)

test result: ok. 14 passed; 0 failed; 0 ignored; 0 measured; 0 filtered out (46ms)
```