### PR TITLE
Fix types

### DIFF
--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -185,8 +185,10 @@ export const deserializeFeed = ((
 		parser.write(input).close();
 	}
 )) as {
-	(input: string): Promise<DeserializationResult<RSS2 | RSS1 | Feed>>;
-	(input: string, options: Options & { outputJsonFeed: true }): Promise<DeserializationResult<JsonFeed>>
+	(input: string): Promise<DeserializationResult<Feed | RSS1 | RSS2>>;
+	(input: string, options: Options & { outputJsonFeed: false }): Promise<DeserializationResult<Feed | RSS1 | RSS2>>;
+	(input: string, options: Options & { outputJsonFeed: true }): Promise<DeserializationResult<JsonFeed>>;
+	(input: string, options?: Options): Promise<DeserializationResult<Feed | JsonFeed | RSS1 | RSS2>>;
 };
 
 interface Attribute {

--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -24,7 +24,7 @@ export interface Options {
 export const deserializeFeed = ((
 	input: string,
 	options?: Options
-) => new Promise<DeserializationResult<RSS2 | RSS1 | Feed | JsonFeed>>(
+) => new Promise<DeserializationResult<Feed | RSS1 | RSS2 | JsonFeed>>(
 	(resolve, reject) => {
 		if (!input) {
 			reject(new Error("Input was undefined, null or empty"));
@@ -115,10 +115,10 @@ export const deserializeFeed = ((
 					onattribute: undefined,
 				});
 
-				const result = new DeserializationResult(
-					options?.outputJsonFeed ? toJsonFeed(feedType, node) : node,
-					options?.outputJsonFeed ? FeedType.JsonFeed : feedType
-				);
+				const result: DeserializationResult<Feed | RSS1 | RSS2 | JsonFeed> = {
+					feed: options?.outputJsonFeed ? toJsonFeed(feedType, node) : node,
+					feedType: options?.outputJsonFeed ? FeedType.JsonFeed : feedType,
+				};
 
 				resolve(result);
 				return;

--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -1,22 +1,20 @@
 import { SAXParser } from "../deps.ts";
 import {
+	DeserializationResult,
 	Feed,
-	RSS2,
-	RSS1,
 	FeedParseType,
 	FeedType,
 	JsonFeed,
-	DeserializationResult
+	RSS1,
+	RSS2,
 } from "./types/mod.ts";
 import {
+	isAtomCDataField,
 	resolveAtomField,
-	resolveRss2Field,
 	resolveRss1Field,
-	isAtomCDataField
+	resolveRss2Field,
 } from "./resolvers/mod.ts";
-import {
-	toJsonFeed
-} from './mapper.ts';
+import { toJsonFeed } from './mapper.ts';
 export interface Options {
 	outputJsonFeed?: boolean
 }

--- a/src/deserializer_test.ts
+++ b/src/deserializer_test.ts
@@ -5,9 +5,7 @@ import {
 	assertNotEquals,
 } from "../test_deps.ts";
 import { deserializeFeed } from "./deserializer.ts";
-import { FeedType, Feed, RSS2, JsonFeed } from "../mod.ts";
-import { } from './types/mod.ts';
-import { DeserializationResult } from './types/deserialization-result.ts';
+import { DeserializationResult, Feed, FeedType, RSS2, Options } from "../mod.ts";
 
 const decoder = new TextDecoder("utf-8");
 
@@ -23,6 +21,23 @@ Deno.test(`Unsupported format handling`, () => {
 	assertThrowsAsync(async () => {
 		await deserializeFeed("<test></test>");
 	});
+});
+
+Deno.test(`Call signatures compile without error`, async () => {
+	const xml = await Deno.readTextFile('./samples/rss2.xml');
+
+	const result1 = await deserializeFeed(xml);
+	const result2 = await deserializeFeed(xml, { outputJsonFeed: true });
+	const result3 = await deserializeFeed(xml, { outputJsonFeed: false });
+
+	const options: Options = {};
+	const result4 = await deserializeFeed(xml, options);
+
+	options.outputJsonFeed = true;
+	const result5 = await deserializeFeed(xml, options);
+
+	options.outputJsonFeed = false;
+	const result6 = await deserializeFeed(xml, options);
 });
 
 Deno.test('Deserialize RSS2', async (): Promise<void> => {

--- a/src/deserializer_test.ts
+++ b/src/deserializer_test.ts
@@ -24,20 +24,20 @@ Deno.test(`Unsupported format handling`, () => {
 });
 
 Deno.test(`Call signatures compile without error`, async () => {
-	const xml = await Deno.readTextFile('./samples/rss2.xml');
+/* because this is a test only for the compiler, the condition is false, so
+ * that none of the code will be executed, but it will still be type-checked
+ */
+	let n = 0;
+	if (n > 0) {
+		const xml = await Deno.readTextFile('./samples/rss2.xml');
 
-	const result1 = await deserializeFeed(xml);
-	const result2 = await deserializeFeed(xml, { outputJsonFeed: true });
-	const result3 = await deserializeFeed(xml, { outputJsonFeed: false });
+		const result1 = await deserializeFeed(xml);
+		const resul2 = await deserializeFeed(xml, { outputJsonFeed: true });
+		const resul3 = await deserializeFeed(xml, { outputJsonFeed: false });
 
-	const options: Options = {};
-	const result4 = await deserializeFeed(xml, options);
-
-	options.outputJsonFeed = true;
-	const result5 = await deserializeFeed(xml, options);
-
-	options.outputJsonFeed = false;
-	const result6 = await deserializeFeed(xml, options);
+		const options: Options = {};
+		const resul4 = await deserializeFeed(xml, options);
+	}
 });
 
 Deno.test('Deserialize RSS2', async (): Promise<void> => {

--- a/src/deserializer_test.ts
+++ b/src/deserializer_test.ts
@@ -32,11 +32,11 @@ Deno.test(`Call signatures compile without error`, async () => {
 		const xml = await Deno.readTextFile('./samples/rss2.xml');
 
 		const result1 = await deserializeFeed(xml);
-		const resul2 = await deserializeFeed(xml, { outputJsonFeed: true });
-		const resul3 = await deserializeFeed(xml, { outputJsonFeed: false });
+		const result2 = await deserializeFeed(xml, { outputJsonFeed: true });
+		const result3 = await deserializeFeed(xml, { outputJsonFeed: false });
 
 		const options: Options = {};
-		const resul4 = await deserializeFeed(xml, options);
+		const result4 = await deserializeFeed(xml, options);
 	}
 });
 

--- a/src/types/deserialization-result.ts
+++ b/src/types/deserialization-result.ts
@@ -1,12 +1,10 @@
 import { Feed } from "./atom.ts"
+import { FeedType } from './feed-type.ts';
 import { JsonFeed } from "./json-feed.ts"
 import { RSS1 } from "./rss1.ts"
 import { RSS2 } from "./rss2.ts"
-import { FeedType } from './feed-type.ts';
 
-export class DeserializationResult<T extends Feed | RSS1 | RSS2 | JsonFeed> {
-	constructor(
-		public feed: T,
-		public feedType: FeedType
-	) {}
+export interface DeserializationResult<T extends Feed | RSS1 | RSS2 | JsonFeed> {
+	feed: T;
+	feedType: T extends JsonFeed ? FeedType.JsonFeed : Exclude<FeedType, FeedType.JsonFeed>;
 }


### PR DESCRIPTION
Hej @MikaelPorttila

[Removing the last type assertion call signature](https://github.com/MikaelPorttila/rss/pull/18/files#diff-7ba960ef2b731a7ed77c89018bbb4ef23d493b401a8759d37e4a7727a094b216R187-R190) from `deserializeFeed` caused a TS error when passing `{ outputJsonFeed: false }` as the options.

Also—in my original PR related to this—it appears I overlooked a couple of other type-related options cases, so I added a test for them.

Additionally, I converted the `DeserializationResult` class to an interface. It seems that none of its class-related properties (like inheritance checking, etc.) were being used other than a single instantiation. I think this change will provide a more transparent result type to the consumer. If you feel strongly about the change, feel free to revert that commit: https://github.com/MikaelPorttila/rss/pull/22/commits/c86c57dc9297a3f3f9c6b1223f2b9b4fb5b81c1b

Cheers!