### PR TITLE
feat: Expose new url field in atom to json mapper

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,8 @@
 {
 	"deno.enable": true,
-	"deno.import_intellisense_origins": {
-		"https://deno.land": true
+	"deno.suggest.autoImports": true,
+	"deno.suggest.imports.hosts": {
+		"https://deno.land/": true
 	},
 	"editor.renderWhitespace": "all"
 }

--- a/benchmark.ts
+++ b/benchmark.ts
@@ -6,9 +6,8 @@ import { deserializeFeed } from "./mod.ts";
 	const loadSample = (sampleName: string): string => {
 		let cacheResult = cache[sampleName];
 		if (!cacheResult) {
-			const decoder = new TextDecoder("utf-8");
-			const result = Deno.readFileSync(`./samples/${sampleName}.xml`);
-			cacheResult = cache[sampleName] = decoder.decode(result);
+			const result = 	Deno.readTextFileSync(`./samples/${sampleName}.xml`);
+			cacheResult = cache[sampleName] = result
 		}
 		return cacheResult;
 	};

--- a/dev.ts
+++ b/dev.ts
@@ -2,17 +2,10 @@ import {
 	deserializeFeed,
 } from "./mod.ts";
 
-const readFile = async (fileName: string): Promise<string> => {
-	const decoder = new TextDecoder("utf-8");
-	const binaryString = await Deno.readFile(fileName);
-	const result = decoder.decode(binaryString);
-	return result;
-}
 
 (async () => {
-	const xml = await readFile(`./samples/${Deno.args[0]}.xml`);
+	const xml = await Deno.readTextFile(`./samples/${Deno.args[0]}.xml`);
 	const { feed } = await deserializeFeed(xml);
-
 	console.log("============ RESULT ============");
 	console.log('Result', feed);
 })();

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -98,18 +98,16 @@ const mapAtomToJsonFeed = (atom: Feed): JsonFeed => {
 		let author;
 		let url: string | undefined;
 
-		if (isValidHttpURL(entry.id)) {
-			url = entry.id;
-		}
-
-		// Recommended but not required field for links in ATOM spec if ID isn't used for that.
-		if (entry["href"]) {
-			url = entry["href"] as string;
-		}
-
 		// All google feeds use this field to provide the correct url.
 		if (entry["feedburner:origlink"]) {
 			url = entry["feedburner:origlink"] as string;
+
+			// Recommended but not required link field in ATOM spec.
+		} else if (entry.href) {
+			url = entry.href;
+
+		} else if (isValidHttpURL(entry.id)) {
+			url = entry.id;
 		}
 
 		if (entry.author) {

--- a/src/mapper_test.ts
+++ b/src/mapper_test.ts
@@ -1,7 +1,4 @@
-import {
-	assert,
-	assertEquals
-} from "../test_deps.ts";
+import { assert, assertEquals } from "../test_deps.ts";
 import type { Feed, RSS2 } from "./types/mod.ts";
 import { FeedType } from "./types/mod.ts";
 import { toJsonFeed } from "./mapper.ts";
@@ -9,7 +6,7 @@ import { toJsonFeed } from "./mapper.ts";
 const date = new Date(1989, 1, 1);
 
 Deno.test("Mapper ATOM -> JSON Feed", () => {
-	const atom = {
+	const atom: Feed = {
 		id: "id",
 		icon: "icon",
 		title: {
@@ -19,54 +16,66 @@ Deno.test("Mapper ATOM -> JSON Feed", () => {
 		links: [{
 			href: "links.href.self",
 			rel: "self",
+			type: ""
 		}, {
 			href: "links.href.alternateOrEmpty",
 			rel: "alternate",
-		}
-		],
-		updated: date,
-		entries: [{
-			id: "entry.id",
-			updated: date,
-			published: date,
-			links: [
-				{
-					href: 'link.href.enclosure',
-					rel: "enclosure",
-					length: 1337,
-					type: "image/test"
-				}
-			],
-			title: {
-				type: 'text',
-				value: 'entry.title.type.text.value'
-			},
-			categories: ["entry.category1", "entry.category2"],
-			summary: {
-				type: "text",
-				value: "entry.summary.type.text.value",
-			},
-			content: {
-				type: "text",
-				value: "entry.content.type.text.value",
-			},
-		}, {
-			id: "entry.id2",
-			summary: {
-				type: "xhtml",
-				value: "entry.summary.type.xhtml.value",
-			},
-			content: {
-				type: "xhtml",
-				value:
-					"<entry.content.type.xhtml.value></<entry.content.type.xhtml.value>",
-			},
+			type: ""
 		}],
+		updated: date,
+		entries: [
+			{
+				id: "entry.id",
+				updated: date,
+				published: date,
+				href: "https://example.com",
+				links: [
+					{
+						href: "link.href.enclosure",
+						rel: "enclosure",
+						length: 1337,
+						type: "image/test",
+					},
+				],
+				title: {
+					type: "text",
+					value: "entry.title.type.text.value",
+				},
+				categories: ["entry.category1", "entry.category2"],
+				summary: {
+					type: "text",
+					value: "entry.summary.type.text.value",
+				},
+				content: {
+					type: "text",
+					value: "entry.content.type.text.value",
+				},
+			},
+			{
+				id: "entry.id2",
+				updated: date,
+				title: {
+					type: "text",
+					value: "text2",
+				},
+				summary: {
+					type: "xhtml",
+					value: "entry.summary.type.xhtml.value",
+				},
+				content: {
+					type: "xhtml",
+					value:
+						"<entry.content.type.xhtml.value></<entry.content.type.xhtml.value>",
+				},
+				"feedburner:origlink":
+					"https://security.googleblog.com/2021/05/introducing-security-by-design.html",
+			},
+		],
 		author: {
 			name: "author.name",
 			uri: "author.url",
 		},
-	} as Feed;
+	};
 
 	const jsonFeed = toJsonFeed(FeedType.Atom, atom);
 	assert(!!jsonFeed, "toJsonFeed result was undefined");
@@ -94,6 +103,19 @@ Deno.test("Mapper ATOM -> JSON Feed", () => {
 		"entry.id",
 		"Atom entry id was not mapped",
 	);
+
+	assertEquals(
+		jsonFeed.items[0].url,
+		"https://example.com",
+		"Atom entry link was not mapped"
+	);
+
+	assertEquals(
+		jsonFeed.items[1].url,
+		"https://security.googleblog.com/2021/05/introducing-security-by-design.html",
+		"Atom entry feed burner link was not mapped."
+	);
+
 	assertEquals(
 		jsonFeed.items[0].title,
 		"entry.title.type.text.value",
@@ -143,88 +165,154 @@ Deno.test("Mapper ATOM -> JSON Feed", () => {
 		"<entry.content.type.xhtml.value></<entry.content.type.xhtml.value>",
 		"Atom entry content with type xhtml was not mapped",
 	);
-	assert(!!jsonFeed.items[0].attachments, 'Atom enclosure link was not mapped');
-	assert(!!jsonFeed.items[0].attachments[0], 'Atom enclosure link was not mapped');
-	assertEquals(jsonFeed.items[0].attachments[0].url, 'link.href.enclosure', 'Atom enclosure link href was not mapped');
-	assertEquals(jsonFeed.items[0].attachments[0].size_in_bytes, 1337, 'Atom enclosure link size was not mapped');
-	assertEquals(jsonFeed.items[0].attachments[0].mime_type, "image/test", 'Atom enclosure link type was not mapped');
-	assertEquals(jsonFeed.items[0].attachments[0].title, undefined, 'Attachment title was not undefined');
-	assertEquals(jsonFeed.items[0].attachments[0].duration_in_seconds, undefined, 'Attachment title was not undefined');
+	assert(!!jsonFeed.items[0].attachments, "Atom enclosure link was not mapped");
+	assert(
+		!!jsonFeed.items[0].attachments[0],
+		"Atom enclosure link was not mapped",
+	);
+	assertEquals(
+		jsonFeed.items[0].attachments[0].url,
+		"link.href.enclosure",
+		"Atom enclosure link href was not mapped",
+	);
+	assertEquals(
+		jsonFeed.items[0].attachments[0].size_in_bytes,
+		1337,
+		"Atom enclosure link size was not mapped",
+	);
+	assertEquals(
+		jsonFeed.items[0].attachments[0].mime_type,
+		"image/test",
+		"Atom enclosure link type was not mapped",
+	);
+	assertEquals(
+		jsonFeed.items[0].attachments[0].title,
+		undefined,
+		"Attachment title was not undefined",
+	);
+	assertEquals(
+		jsonFeed.items[0].attachments[0].duration_in_seconds,
+		undefined,
+		"Attachment title was not undefined",
+	);
 });
 
 Deno.test("Mapper RSS2 -> JSON Feed", () => {
 	const rss: RSS2 = {
 		version: 2,
 		channel: {
-			title: 'title',
-			link: 'link',
-			description: 'description',
-			managingEditor: 'managingEditor',
-			webMaster: 'webMaster',
+			title: "title",
+			link: "link",
+			description: "description",
+			managingEditor: "managingEditor",
+			webMaster: "webMaster",
 			image: {
-				url: 'image.url',
-				title: 'image.title',
-				link: 'image.link'
+				url: "image.url",
+				title: "image.title",
+				link: "image.link",
 			},
 			items: [{
-				guid: 'item.guid',
-				title: 'item.title',
-				description: 'item.description',
-				author: 'item.author',
-				link: 'item.link',
-				comments: 'item.comments',
-				categories: ['item.link.category1', 'item.link.category2'],
+				guid: "item.guid",
+				title: "item.title",
+				description: "item.description",
+				author: "item.author",
+				link: "item.link",
+				comments: "item.comments",
+				categories: ["item.link.category1", "item.link.category2"],
 				pubDate: new Date(1989, 1, 1),
 				enclosure: {
-					url: 'enclosure.url',
+					url: "enclosure.url",
 					length: 1337,
-					type: 'enclosure.type'
-				}
+					type: "enclosure.type",
+				},
 			}],
 			cloud: {
-				domain: 'cloud.domain',
+				domain: "cloud.domain",
 				port: 1337,
-				path: '/cloud.path',
-				registerProcedure: 'cloud.registerProcedure',
-				protocol: 'cloud.protocol'
-			}
-		}
+				path: "/cloud.path",
+				registerProcedure: "cloud.registerProcedure",
+				protocol: "cloud.protocol",
+			},
+		},
 	};
 
 	const jsonFeed = toJsonFeed(FeedType.Rss2, rss);
 	// Channel
-	assert(!!jsonFeed, 'toJsonFeed result was undefined');
-	assertEquals(jsonFeed.title, 'title', 'RSS title was not mapped');
-	assertEquals(jsonFeed.description, 'description', 'RSS description was not mapped');
+	assert(!!jsonFeed, "toJsonFeed result was undefined");
+	assertEquals(jsonFeed.title, "title", "RSS title was not mapped");
+	assertEquals(
+		jsonFeed.description,
+		"description",
+		"RSS description was not mapped",
+	);
 	// Author
-	assert(!!jsonFeed.author, 'author field is undefined, RSS webMaster or managingEditor was not mapped');
-	assertEquals(jsonFeed.author.url, 'managingEditor', 'RSS webMaster or managingEditor was not mapped');
-	assert(!!jsonFeed.icon, 'RSS Image was not mapped');
-	assertEquals(jsonFeed.icon, 'image.url', 'RSS Image was not mapped');
-	assertEquals(jsonFeed.home_page_url, 'link', 'RSS link was not mapped');
+	assert(
+		!!jsonFeed.author,
+		"author field is undefined, RSS webMaster or managingEditor was not mapped",
+	);
+	assertEquals(
+		jsonFeed.author.url,
+		"managingEditor",
+		"RSS webMaster or managingEditor was not mapped",
+	);
+	assert(!!jsonFeed.icon, "RSS Image was not mapped");
+	assertEquals(jsonFeed.icon, "image.url", "RSS Image was not mapped");
+	assertEquals(jsonFeed.home_page_url, "link", "RSS link was not mapped");
 	// hub
-	assert(!!jsonFeed.hubs, 'RSS cloud was not mapped');
-	assertEquals(jsonFeed.hubs[0].type, 'cloud.protocol');
-	assertEquals(jsonFeed.hubs[0].url, 'cloud.domain:1337/cloud.path');
+	assert(!!jsonFeed.hubs, "RSS cloud was not mapped");
+	assertEquals(jsonFeed.hubs[0].type, "cloud.protocol");
+	assertEquals(jsonFeed.hubs[0].url, "cloud.domain:1337/cloud.path");
 	// Items
-	assert(!!jsonFeed.items, 'RSS Items were not mapped');
+	assert(!!jsonFeed.items, "RSS Items were not mapped");
 	const item = jsonFeed.items[0];
-	assertEquals(item.id, 'item.guid', 'Item guid was not mapped');
-	assertEquals(item.title, 'item.title', 'Item title was not mapped');
-	assertEquals(item.external_url, 'item.link', 'Item link was not mapped');
-	assertEquals(item.content_html, 'item.link', 'Item link was not mapped');
-	assertEquals(item.date_published, new Date(1989, 1, 1), 'Item PubDate was not mapped');
+	assertEquals(item.id, "item.guid", "Item guid was not mapped");
+	assertEquals(item.title, "item.title", "Item title was not mapped");
+	assertEquals(item.external_url, "item.link", "Item link was not mapped");
+	assertEquals(item.content_html, "item.link", "Item link was not mapped");
+	assertEquals(
+		item.date_published,
+		new Date(1989, 1, 1),
+		"Item PubDate was not mapped",
+	);
 
-	assert(!!item.author, 'RSS Item author was not mapped');
-	assertEquals(item.author.name, 'item.author', 'RSS Item author was not mapped');
-	assertEquals(item.author.avatar, undefined, 'Author avatar should be undefined');
-	assertEquals(item.author.url, undefined, 'Author url should be undefined');
+	assert(!!item.author, "RSS Item author was not mapped");
+	assertEquals(
+		item.author.name,
+		"item.author",
+		"RSS Item author was not mapped",
+	);
+	assertEquals(
+		item.author.avatar,
+		undefined,
+		"Author avatar should be undefined",
+	);
+	assertEquals(item.author.url, undefined, "Author url should be undefined");
 
-	assert(!!item.attachments, 'Enclosure was not mapped');
+	assert(!!item.attachments, "Enclosure was not mapped");
 	const attachment = item.attachments[0];
-	assertEquals(attachment.url, 'enclosure.url', 'Item Enclosure Url was not mapped');
-	assertEquals(attachment.size_in_bytes, 1337, 'Item Enclosure length was not mapped');
-	assertEquals(attachment.mime_type, 'enclosure.type', 'Item Enclosure type was not mapped');
-	assertEquals(attachment.duration_in_seconds, undefined, 'Attachment duration_in_seconds was not undefined');
-	assertEquals(attachment.title, undefined, 'Attachment title was not undefined');
+	assertEquals(
+		attachment.url,
+		"enclosure.url",
+		"Item Enclosure Url was not mapped",
+	);
+	assertEquals(
+		attachment.size_in_bytes,
+		1337,
+		"Item Enclosure length was not mapped",
+	);
+	assertEquals(
+		attachment.mime_type,
+		"enclosure.type",
+		"Item Enclosure type was not mapped",
+	);
+	assertEquals(
+		attachment.duration_in_seconds,
+		undefined,
+		"Attachment duration_in_seconds was not undefined",
+	);
+	assertEquals(
+		attachment.title,
+		undefined,
+		"Attachment title was not undefined",
+	);
 });

--- a/src/types/atom.ts
+++ b/src/types/atom.ts
@@ -41,6 +41,7 @@ interface Entry {
 	rights?: Text;
 	categories?: string[];
 	source?: Source;
+	[key: string]: unknown
 }
 
 interface Content extends Text {

--- a/src/types/atom.ts
+++ b/src/types/atom.ts
@@ -41,7 +41,8 @@ interface Entry {
 	rights?: Text;
 	categories?: string[];
 	source?: Source;
-	[key: string]: unknown
+	href?: string;
+	[key: string]: any;
 }
 
 interface Content extends Text {

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,0 +1,10 @@
+export function isValidHttpURL(text: string) {
+    let url: URL
+    try {
+      url = new URL(text);
+    } catch (_) {
+      return false;
+    }
+    return url.protocol === "http:" || url.protocol === "https:";
+  }
+  

--- a/src/util.ts
+++ b/src/util.ts
@@ -1,10 +1,9 @@
 export function isValidHttpURL(text: string) {
     let url: URL
     try {
-      url = new URL(text);
+        url = new URL(text);
     } catch (_) {
-      return false;
+        return false;
     }
-    return url.protocol === "http:" || url.protocol === "https:";
-  }
-  
+    return ["https:", "http:"].includes(url.protocol)
+}

--- a/src/util_test.ts
+++ b/src/util_test.ts
@@ -1,0 +1,9 @@
+import { assert } from "../test_deps.ts"
+import { isValidHttpURL } from "./util.ts"
+
+Deno.test("is valid HTTP URL", () => {
+    assert(isValidHttpURL("https://shopify.engineering/shipit-writing-react-native-apps"))
+    assert(isValidHttpURL("http://shopify.engineering/shipit-writing-react-native-apps"))
+    assert(!isValidHttpURL("test.com/test"))
+    assert(!isValidHttpURL("test/data/test"))
+})


### PR DESCRIPTION
As described in the #25, some atom feeds don't provide url in the ID. They do it in a separate link which isn't exposed. I have exposed that and added an edge case for feeds using feedburner (afaik, only google use it on all of their properties). 

I could rename it to link according to atom spec https://validator.w3.org/feed/docs/atom.html but url aligns with json feed which is the output. 

The value of title on google feeds and few other aren't nested. I think it may be a bug on the parser end or schema. I have added a simple fall through if it that's the case. It shouldn't break anything for existing users. 
