### PR TITLE
Expose original date values and undefined/null checking in mapper

### DIFF
--- a/dev.ts
+++ b/dev.ts
@@ -5,7 +5,7 @@ import {
 
 (async () => {
 	const xml = await Deno.readTextFile(`./samples/${Deno.args[0]}.xml`);
-	const { feed } = await deserializeFeed(xml);
+	const { feed } = await deserializeFeed(xml, { outputJsonFeed: true });
 	console.log("============ RESULT ============");
 	console.log('Result', feed);
 })();

--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -39,7 +39,6 @@ export const deserializeFeed = ((
 		let cDataBuilder: string;
 		let cDataActive: boolean;
 		let feedType: FeedType;
-		let currentElement;
 		const stack: any[] = [{}];
 		const parser = new SAXParser(false, {
 			trim: true,
@@ -149,13 +148,15 @@ export const deserializeFeed = ((
 				isDate,
 			] = resolveField(nodeName);
 
+			const targetNode = stack[stack.length - 1];
+
 			if (isNumber) {
 				node = parseInt(node);
 			} else if (isDate) {
+				targetNode[propertyName + 'Raw'] = node;
 				node = new Date(node);
 			}
 
-			const targetNode = stack[stack.length - 1];
 			if (isArray) {
 				if (!targetNode[propertyName]) {
 					targetNode[propertyName] = [node];

--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -98,7 +98,12 @@ export const deserializeFeed = ((
 				return;
 			}
 
-			stack[stack.length - 1][attr.name] = attr.value.trim();
+			try {
+				stack[stack.length - 1][attr.name] = attr.value.trim();
+			}
+			catch {
+				console.error(`Failed to assign property ${attr.name} with the value ${attr?.value?.trim()}`);
+			}
 		};
 
 		parser.onclosetag = (nodeName: string) => {
@@ -169,8 +174,14 @@ export const deserializeFeed = ((
 					Object.keys(node).length === 0 &&
 					!(node instanceof Date);
 
-				if (!isEmpty) {
-					targetNode[propertyName] = node;
+
+				try {
+					if (!isEmpty) {
+						targetNode[propertyName] = node;
+					}
+				}
+				catch {
+					console.error(`Failed to add property ${propertyName} on node`, targetNode);
 				}
 			}
 		};

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -34,7 +34,7 @@ export const toJsonFeed = (
 };
 
 const mapRss2ToJsonFeed = (rss: RSS2): JsonFeed => {
-	const items = rss.channel.items.map((rssItem) => {
+	const items = rss.channel?.items?.map((rssItem) => {
 		let authors, author, attachments;
 
 		if (rssItem.author) {
@@ -45,9 +45,9 @@ const mapRss2ToJsonFeed = (rss: RSS2): JsonFeed => {
 		}
 		else if (rssItem['dc:creator']) {
 			author = {
-				name: rssItem['dc:creator'][0],
+				name: rssItem['dc:creator']?.[0],
 			};
-			authors = rssItem['dc:creator'].map(creator => ({name: creator}));
+			authors = rssItem['dc:creator']?.map(creator => ({name: creator}));
 		}
 
 		if (rssItem.enclosure) {
@@ -78,13 +78,13 @@ const mapRss2ToJsonFeed = (rss: RSS2): JsonFeed => {
 	const channel = rss.channel;
 	let author, hubs;
 
-	if (channel.managingEditor || channel.webMaster) {
+	if (channel && (channel.managingEditor || channel.webMaster)) {
 		author = {
 			url: channel.managingEditor || channel.webMaster,
 		};
 	}
 
-	if (channel.cloud) {
+	if (channel?.cloud) {
 		hubs = [{
 			type: channel.cloud.protocol,
 			url: `${channel.cloud.domain}${channel.cloud.port ? ":" + channel.cloud.port : ""
@@ -93,10 +93,10 @@ const mapRss2ToJsonFeed = (rss: RSS2): JsonFeed => {
 	}
 
 	return {
-		title: channel.title,
-		description: channel.description,
-		icon: channel.image?.url,
-		home_page_url: channel.link,
+		title: channel?.title,
+		description: channel?.description,
+		icon: channel?.image?.url,
+		home_page_url: channel?.link,
 		items,
 		author,
 		hubs,

--- a/src/mapper.ts
+++ b/src/mapper.ts
@@ -69,7 +69,9 @@ const mapRss2ToJsonFeed = (rss: RSS2): JsonFeed => {
 			attachments,
 			url: rssItem.link,
 			date_published: rssItem.pubDate,
+			date_publishedRaw: rssItem.pubDateRaw,
 			date_modified: rssItem.pubDate,
+			date_modifiedRaw: rssItem.pubDateRaw,
 		} as JsonFeedItem;
 	}) || [];
 
@@ -137,7 +139,9 @@ const mapAtomToJsonFeed = (atom: Feed): JsonFeed => {
 			id: entry.id,
 			title: entry.title?.value ?? entry.title,
 			date_published: entry.published,
+			date_publishedRaw: entry.publishedRaw,
 			date_modified: entry.updated,
+			date_modifiedRaw: entry.updatedRaw,
 			summary: entry.summary?.value,
 			tags: entry.categories,
 			author,

--- a/src/types/atom.ts
+++ b/src/types/atom.ts
@@ -4,6 +4,7 @@ export interface Feed {
 	id: string;
 	title: Text;
 	updated: Date;
+	updatedRaw: string;
 	icon?: string;
 	links?: Link[];
 	entries: Entry[];
@@ -32,7 +33,9 @@ interface Entry {
 	id: string;
 	title: Text;
 	updated: Date;
+	updatedRaw: string;
 	published?: Date;
+	publishedRaw?: string;
 	content?: Content;
 	links?: Link[];
 	author?: Person;
@@ -59,6 +62,7 @@ interface Source {
 	id?: string;
 	title?: string;
 	updated?: Date;
+	updatedRaw?: Date;
 }
 
 interface Text {

--- a/src/types/json-feed.ts
+++ b/src/types/json-feed.ts
@@ -24,10 +24,12 @@ export interface JsonFeedItem {
 	url?: string;
 	external_url?: string;
 	date_published?: Date;
+	date_publishedRaw?: string;
 	summary?: string;
 	image?: string;
 	banner_image?: string;
 	date_modified?: Date;
+	date_modifiedRaw?: string;
 	authors?: JsonFeedAuthor[];
 	/**
 	 * @deprecated Please use the new JsonFeed 1.1 authors field instead.

--- a/src/types/rss2.ts
+++ b/src/types/rss2.ts
@@ -15,7 +15,9 @@ interface Channel {
 	managingEditor?: string;
 	webMaster?: string;
 	pubDate?: Date;
+	pubDateRaw?: string;
 	lastBuildDate?: Date;
+	lastBuildDateRaw?: string;
 	category?: string[];
 	generator?: string;
 	docs?: string;
@@ -37,6 +39,7 @@ interface Item {
 	enclosure?: Enclosure;
 	guid?: string;
 	pubDate?: Date;
+	pubDateRaw?: string;
 	source?: Source;
 	'dc:creator'?: string[];
 }


### PR DESCRIPTION
- Provides a way to access the original date string from the feed.
- undefined/null handling in mapper for channel object.