### PR TITLE
fix: handle a rejection in parseFeed

### DIFF
--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -27,17 +27,13 @@ import {
  * Parse Atom or RSS into a common Feed type
  * @param Atom or RSS XML string
  */
-export function parseFeed(input: string): Promise<Feed> {
-  return new Promise<Feed>(async (resolve, reject) => {
-    if (!input) {
-      reject(new Error("Input was undefined, null or empty"));
-      return;
-    }
+export async function parseFeed(input: string): Promise<Feed> {
+  if (!input) {
+    throw new Error("Input was undefined, null or empty");
+  }
 
-    const { data, feedType } = await parse(input);
-    const result = toFeed(feedType, data) as Feed;
-    resolve(result);
-  });
+  const { data, feedType } = await parse(input);
+  return toFeed(feedType, data)!;
 }
 
 export interface Options {


### PR DESCRIPTION
I was experiencing parse failures because `parse` was throwing an exception in the Promise initializer in `parseFeed`. This PR makes `parseFeed` async so that any internal errors will be propagated as rejections.
