### PR TITLE
Fix exception with empty author name

### DIFF
--- a/samples/atom.xml
+++ b/samples/atom.xml
@@ -114,6 +114,10 @@
     </media:group>
   </entry>
 	<entry>
+		<author>
+			<name></name>
+			<email>example@example.com</email>
+		</author>
 		<title type="xhtml"><div><img src="test" /><img src="test2" /></div></title>
 		<summary type="xhtml"><div><img src="test" /><img src="test2" /></div></summary>
 	</entry>

--- a/src/mappers/mapper.ts
+++ b/src/mappers/mapper.ts
@@ -477,7 +477,7 @@ const mapAtomToFeed = (atom: InternalAtom): Feed => {
     if (author) {
       entry.author = {
         email: author.email?.value,
-        name: author.name.value,
+        name: author.name?.value,
         uri: author.uri?.value,
       };
     }


### PR DESCRIPTION
Fix an exception when an `<entry>` has an `<author>` with an empty `<name>` element.