### PR TITLE
Fix empty node name

### DIFF
--- a/src/deserializer.ts
+++ b/src/deserializer.ts
@@ -180,16 +180,19 @@ const parse = (input: string) => new Promise<{ feedType: FeedType; data: any }>(
         }
       }
 
-      if (isArray) {
-        if (!targetNode[name]) {
-          targetNode[name] = [node];
-        } else {
-          targetNode[name].push(node);
-        }
-      } else {
-        const isEmpty = (typeof node === "object") &&
+      const isEmpty = (typeof node === "object") &&
           Object.keys(node).length === 0 &&
           !(node instanceof Date);
+
+      if (isArray) {
+        const nameNode = isEmpty ? "" : node;
+        if (!targetNode[name]) {
+          targetNode[name] = [nameNode];
+        } else {
+          targetNode[name].push(nameNode);
+        }
+      } else {
+       
         try {
           if (!isEmpty) {
             targetNode[name] = node;

--- a/src/deserializer_test.ts
+++ b/src/deserializer_test.ts
@@ -786,3 +786,15 @@ Deno.test("Should throw error on unsupported feed format", async () => {
     "Type xrss is not supported",
   );
 });
+
+Deno.test("Test empty node", async () => {
+  const feed = await parseFeed(`<rss version="2.0"
+	>
+  <channel>
+    <item>
+      <dc:creator><![CDATA[]]></dc:creator>
+    </item>
+  </channel>
+  </rss>`);
+  feed.entries[0].author?.name?.substring(0,1)
+})


### PR DESCRIPTION
I ran into an issue when parsing the feed from `https://engineering.fb.com/feed/` (so this is a real problem, not hypothetical), where the name field was not a string when the node was empty (for example  <dc:creator><![CDATA[]]></dc:creator>).

I added a reproducible test case to `deserializer_test.ts`:
```typescript
Deno.test("Test empty node", async () => {
  const feed = await parseFeed(`<rss version="2.0"
	>
  <channel>
    <item>
      <dc:creator><![CDATA[]]></dc:creator>
    </item>
  </channel>
  </rss>`);
  feed.entries[0].author?.name?.substring(0,1)
})
```

which throws an error without this fix:

```typescript
 const isEmpty = (typeof node === "object") &&
          Object.keys(node).length === 0 &&
          !(node instanceof Date);

      if (isArray) {
        const nameNode = isEmpty ? "" : node;
        if (!targetNode[name]) {
          targetNode[name] = [nameNode];
        } else {
          targetNode[name].push(nameNode);
        }
      } else {
```
where I simply just check if the node is an empty object and if so, change the targetNode name to empty string instead of the node.

Now all tests pass :)